### PR TITLE
libjs: Make the error regex more liberal

### DIFF
--- a/lib/agents/libjs.js
+++ b/lib/agents/libjs.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const runtimePath = require('../runtime-path');
 const ConsoleAgent = require('../ConsoleAgent');
 
-const errorRe = /^Uncaught exception:(?: \[(.+?)])?(?: (.+))?((?:\n -> .+|\n \d+? more calls)*)?\n?/m;
+const errorRe = /^Uncaught exception:(?:\s+\[(.+?)])?(?: (.+))?((?:\n -> .+|\n \d+? more calls)*)?\n?/m;
 
 class LibJSAgent extends ConsoleAgent {
   constructor(options) {


### PR DESCRIPTION
`Uncaught exception:` is usually followed by `\n`