### PR TITLE
kiesel: disable promise rejection warnings

### DIFF
--- a/lib/agents/kiesel.js
+++ b/lib/agents/kiesel.js
@@ -7,6 +7,12 @@ const ConsoleAgent = require('../ConsoleAgent');
 const errorRe = /^Uncaught exception: (.+?)(?:: (.+))?$/m;
 
 class KieselAgent extends ConsoleAgent {
+  constructor(options) {
+    super(options);
+
+    this.args.unshift('--print-promise-rejection-warnings=no');
+  }
+
   async evalScript(code, options = {}) {
     if (options.module && this.args[0] !== '--module') {
       this.args.unshift('--module');


### PR DESCRIPTION
This breaks test262-harness and anything else that can't deal with random stuff printed to stdout/stderr.