### PR TITLE
boa: Fix strict mode error in `createRealm`

### DIFF
--- a/runtimes/boa.js
+++ b/runtimes/boa.js
@@ -11,7 +11,7 @@ var $262 = {
     options = options || {};
     options.globals = options.globals || {};
 
-    context = {
+    var context = {
       print: print,
     };
 


### PR DESCRIPTION
Hi @CanadaHonk, I noticed a few `ReferenceError`s in the boa results in realm related tests.

I tested this fix locally and it works as expected.