### PR TITLE
nova: Support non-strict mode

### DIFF
--- a/lib/agents/nova.js
+++ b/lib/agents/nova.js
@@ -11,7 +11,7 @@ class NovaAgent extends ConsoleAgent {
   constructor(options) {
     super(options);
 
-    this.args.unshift('eval');
+    this.args.unshift('eval', '--no-strict');
   }
 
   async evalScript(code, options = {}) {


### PR DESCRIPTION
trynova/nova#319 implemented the distinction between strict and non-strict mode in Nova, but it also made strict mode the default for nova_cli. This patch changes the Nova runner to use the `--no-strict` flag, which enables non-strict mode.