### PR TITLE
graaljs: fix --module argument position

### DIFF
--- a/lib/agents/graaljs.js
+++ b/lib/agents/graaljs.js
@@ -13,20 +13,25 @@ class GraalJSAgent extends ConsoleAgent {
     super(options);
 
     this.args.unshift(
-      '--js.test262-mode=true',
-      '--js.intl-402=true',
-      '--js.ecmascript-version=2022',
-      '--experimental-options'
+      '--experimental-options',
+      '--js.test262-mode=true'
     );
+
+    if (options.experimental) {
+      this.args.unshift(
+        '--js.ecmascript-version=staging',
+        '--js.temporal=true'
+      );
+    }
   }
 
   async evalScript(code, options = {}) {
-    if (options.module && this.args[0] !== '--module') {
-      this.args.unshift('--module');
+    if (options.module && this.args[this.args.length - 1] !== '--module') {
+      this.args.push('--module');
     }
 
-    if (!options.module && this.args[0] === '--module') {
-      this.args.shift();
+    if (!options.module && this.args[this.args.length - 1] === '--module') {
+      this.args.pop();
     }
 
     return super.evalScript(code, options);


### PR DESCRIPTION
GraalJS needs the `--module` argument to be placed right before the module file to work.
Therefore, I've changed the code the append, rather than prepend, `--module` for module tests. This should fix errors like:
```
Error: Could not find or load file --js.test262-mode=true.
```

I've also cleaned up the default arguments a bit: `--js.intl-402=true` is unnecessary since it's already the default for quite some time and `--js.ecmascript-version=2022` unnecessarily limits the ECMAScript version to 2022 instead of just using the latest supported released version (i.e., 2024).

Instead, I've added an experimental mode (currently unused) that enables any already supported "ESNext" features (`--js.ecmascript-version=staging`) and specifically, the Temporal proposal (--js.temporal=true). There are more flags that we could add here, but I wanted to keep it minimal since eventually, these features will be enabled by default anyway.
